### PR TITLE
Fix error during MCP9808 creation

### DIFF
--- a/mcp9808.py
+++ b/mcp9808.py
@@ -55,6 +55,9 @@ class MCP9808(object):
         """
         Sends the given bufer object over I2C to the sensor.
         """
+        if not isinstance(buf, bytearray):
+            buf = bytearray([buf])
+
         if hasattr(self._i2c, "writeto"):
             # Micropython
             self._i2c.writeto(self._addr, buf)


### PR DESCRIPTION
I was getting the following error:
```
>>> mcp = MCP9808(i2c)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mcp9808.py", line 52, in __init__
  File "mcp9808.py", line 86, in _check_device
  File "mcp9808.py", line 60, in _send
TypeError: object with buffer protocol required
```
This was a result of sending in plain integers to the `_send()` method. This solution checks to see if the input is a `bytearray` (which is used elsewhere in the code) and creates one if it is not.